### PR TITLE
add suport for get_farmed_amount data

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ chia_wallet_sync_status{wallet_id="1",wallet_fingerprint="103402894"} 0
 # HELP chia_wallet_unconfirmed_balance_mojo Unconfirmed wallet balance.
 # TYPE chia_wallet_unconfirmed_balance_mojo gauge
 chia_wallet_unconfirmed_balance_mojo{wallet_id="1",wallet_fingerprint="103402894"} 100
+# HELP chia_wallet_farmed_amount Farmed amount
+# TYPE chia_wallet_farmed_amount gauge
+chia_wallet_farmed_amount{wallet_fingerprint="103402894",wallet_id="1"} 0
+# HELP chia_wallet_fee_amount Fee amount amount
+# TYPE chia_wallet_fee_amount gauge
+chia_wallet_fee_amount{wallet_fingerprint="103402894",wallet_id="1"} 0
+# HELP chia_wallet_last_height_farmed Last height farmed
+# TYPE chia_wallet_last_height_farmed gauge
+chia_wallet_last_height_farmed{wallet_fingerprint="103402894",wallet_id="1"} 0
+# HELP chia_wallet_pool_reward_amount Pool Reward amount
+# TYPE chia_wallet_pool_reward_amount gauge
+chia_wallet_pool_reward_amount{wallet_fingerprint="103402894",wallet_id="1"} 0
+# HELP chia_wallet_reward_amount Reward amount
+# TYPE chia_wallet_reward_amount gauge
+chia_wallet_reward_amount{wallet_fingerprint="103402894",wallet_id="1"} 0
 ```
 
 ### Blockchain
@@ -115,4 +130,7 @@ endpoint. The wallet metrics are collected for each wallet, and include
   [get_height_info](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces#get_height_info)
   endpoint.
 
+* Farmed ammount and reward are collected from the
+  [get_farmed_amount](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces#get_farmed_amount)
+  endpoint.
 

--- a/chia.go
+++ b/chia.go
@@ -129,3 +129,12 @@ type WalletPublicKeys struct {
 	PublicKeyFingerprints []int `json:"public_key_fingerprints"`
 	Success               bool
 }
+
+type FarmedAmount struct {
+  FarmedAmount          int64    `json:"farmed_amount"`
+	RewardAmount          int64    `json:"farmer_reward_amount"`
+	FeeAmount             int64    `json:"fee_amount"`
+	LastHeightFarmed      int64    `json:"last_height_farmed"`
+	PoolRewardAmount      int64    `json:"pool_reward_amount"`
+	Success               bool
+}

--- a/chia.go
+++ b/chia.go
@@ -131,10 +131,10 @@ type WalletPublicKeys struct {
 }
 
 type FarmedAmount struct {
-  FarmedAmount          int64    `json:"farmed_amount"`
-	RewardAmount          int64    `json:"farmer_reward_amount"`
-	FeeAmount             int64    `json:"fee_amount"`
-	LastHeightFarmed      int64    `json:"last_height_farmed"`
-	PoolRewardAmount      int64    `json:"pool_reward_amount"`
-	Success               bool
+	FarmedAmount     int64 `json:"farmed_amount"`
+	RewardAmount     int64 `json:"farmer_reward_amount"`
+	FeeAmount        int64 `json:"fee_amount"`
+	LastHeightFarmed int64 `json:"last_height_farmed"`
+	PoolRewardAmount int64 `json:"pool_reward_amount"`
+	Success          bool
 }

--- a/chia.go
+++ b/chia.go
@@ -129,3 +129,17 @@ type WalletPublicKeys struct {
 	PublicKeyFingerprints []int `json:"public_key_fingerprints"`
 	Success               bool
 }
+
+type PoolState struct {
+  PoolState             []struct {
+    CurrentDificulty      int64     `json:"current_difficulty"`
+    CurrentPoints         int64     `json:"current_points"`
+    PointsAcknowledged24h []interface{}   `json:"points_acknowledged_24h"`
+    PointsFound24h        []interface{}   `json:"points_found_24h"`
+    PoolConfig            struct {
+      LauncherId            string     `json:"launcher_id"`
+      PoolURL               string     `json:"pool_url"`
+    } `json:"pool_config"`
+  }      `json:"pool_state"`
+	Success               bool
+}

--- a/chia.go
+++ b/chia.go
@@ -138,17 +138,3 @@ type FarmedAmount struct {
 	PoolRewardAmount      int64    `json:"pool_reward_amount"`
 	Success               bool
 }
-
-type PoolState struct {
-  PoolState             []struct {
-    CurrentDificulty      int64     `json:"current_difficulty"`
-    CurrentPoints         int64     `json:"current_points"`
-    PointsAcknowledged24h []interface{}   `json:"points_acknowledged_24h"`
-    PointsFound24h        []interface{}   `json:"points_found_24h"`
-    PoolConfig            struct {
-      LauncherId            string     `json:"launcher_id"`
-      PoolURL               string     `json:"pool_url"`
-    } `json:"pool_config"`
-  }      `json:"pool_state"`
-	Success               bool
-}

--- a/main.go
+++ b/main.go
@@ -381,51 +381,51 @@ func (cc ChiaCollector) collectFarmedAmount(ch chan<- prometheus.Metric, w Walle
 		return
 	}
 	ch <- prometheus.MustNewConstMetric(
-	  prometheus.NewDesc(
-		  "chia_wallet_farmed_amount",
-		  "Farmed amount",
-		  []string{"wallet_id", "wallet_fingerprint"}, nil,
-	  ),
+		prometheus.NewDesc(
+			"chia_wallet_farmed_amount",
+			"Farmed amount",
+			[]string{"wallet_id", "wallet_fingerprint"}, nil,
+		),
 		prometheus.GaugeValue,
 		float64(farmed.FarmedAmount),
 		w.StringID, w.PublicKey,
 	)
 	ch <- prometheus.MustNewConstMetric(
-	  prometheus.NewDesc(
-		  "chia_wallet_reward_amount",
-		  "Reward amount",
-		  []string{"wallet_id", "wallet_fingerprint"}, nil,
-	  ),
+		prometheus.NewDesc(
+			"chia_wallet_reward_amount",
+			"Reward amount",
+			[]string{"wallet_id", "wallet_fingerprint"}, nil,
+		),
 		prometheus.GaugeValue,
 		float64(farmed.RewardAmount),
 		w.StringID, w.PublicKey,
 	)
 	ch <- prometheus.MustNewConstMetric(
-	  prometheus.NewDesc(
-		  "chia_wallet_fee_amount",
-		  "Fee amount amount",
-		  []string{"wallet_id", "wallet_fingerprint"}, nil,
-	  ),
+		prometheus.NewDesc(
+			"chia_wallet_fee_amount",
+			"Fee amount amount",
+			[]string{"wallet_id", "wallet_fingerprint"}, nil,
+		),
 		prometheus.GaugeValue,
 		float64(farmed.FeeAmount),
 		w.StringID, w.PublicKey,
 	)
 	ch <- prometheus.MustNewConstMetric(
-	  prometheus.NewDesc(
-		  "chia_wallet_last_height_farmed",
-		  "Last height farmed",
-		  []string{"wallet_id", "wallet_fingerprint"}, nil,
-	  ),
+		prometheus.NewDesc(
+			"chia_wallet_last_height_farmed",
+			"Last height farmed",
+			[]string{"wallet_id", "wallet_fingerprint"}, nil,
+		),
 		prometheus.GaugeValue,
 		float64(farmed.LastHeightFarmed),
 		w.StringID, w.PublicKey,
 	)
 	ch <- prometheus.MustNewConstMetric(
-	  prometheus.NewDesc(
-		  "chia_wallet_pool_reward_amount",
-		  "Pool Reward amount",
-		  []string{"wallet_id", "wallet_fingerprint"}, nil,
-	  ),
+		prometheus.NewDesc(
+			"chia_wallet_pool_reward_amount",
+			"Pool Reward amount",
+			[]string{"wallet_id", "wallet_fingerprint"}, nil,
+		),
 		prometheus.GaugeValue,
 		float64(farmed.PoolRewardAmount),
 		w.StringID, w.PublicKey,

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var (
 )
 
 var (
-	Version = "0.4.1"
+	Version = "0.4.1a"
 )
 
 func main() {
@@ -237,6 +237,7 @@ func (cc ChiaCollector) collectWallets(ch chan<- prometheus.Metric) {
 		w.PublicKey = cc.getWalletPublicKey(w)
 		cc.collectWalletBalance(ch, w)
 		cc.collectWalletSync(ch, w)
+		cc.collectFarmedAmount(ch, w)
 	}
 }
 
@@ -368,6 +369,65 @@ func (cc ChiaCollector) collectWalletSync(ch chan<- prometheus.Metric, w Wallet)
 		walletHeightDesc,
 		prometheus.GaugeValue,
 		float64(whi.Height),
+		w.StringID, w.PublicKey,
+	)
+}
+
+func (cc ChiaCollector) collectFarmedAmount(ch chan<- prometheus.Metric, w Wallet) {
+	var farmed FarmedAmount
+	q := fmt.Sprintf(`{"wallet_id":%d}`, w.ID)
+	if err := queryAPI(cc.client, cc.walletURL, "get_farmed_amount", q, &farmed); err != nil {
+		log.Print(err)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_farmed_amount",
+		  "Farmed amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.FarmedAmount),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_reward_amount",
+		  "Reward amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.RewardAmount),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_fee_amount",
+		  "Fee amount amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.FeeAmount),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_last_height_farmed",
+		  "Last height farmed",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.LastHeightFarmed),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_pool_reward_amount",
+		  "Pool Reward amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.PoolRewardAmount),
 		w.StringID, w.PublicKey,
 	)
 }

--- a/main.go
+++ b/main.go
@@ -39,11 +39,10 @@ var (
 	key    = flag.String("key", "$HOME/.chia/mainnet/config/ssl/full_node/private_full_node.key", "The full node SSL key.")
 	url    = flag.String("url", "https://localhost:8555", "The base URL for the full node RPC endpoint.")
 	wallet = flag.String("wallet", "https://localhost:9256", "The base URL for the wallet RPC endpoint.")
-	farmer = flag.String("farmer", "https://localhost:8559", "The base URL for the farmer RPC endpoint.")
 )
 
 var (
-	Version = "0.4.1c"
+	Version = "0.4.1"
 )
 
 func main() {
@@ -65,7 +64,6 @@ func main() {
 		client:    client,
 		baseURL:   *url,
 		walletURL: *wallet,
-		farmerURL: *farmer,
 	}
 	prometheus.MustRegister(cc)
 
@@ -130,7 +128,6 @@ type ChiaCollector struct {
 	client    *http.Client
 	baseURL   string
 	walletURL string
-	farmerURL string
 }
 
 // Describe is implemented with DescribeByCollect.
@@ -143,7 +140,6 @@ func (cc ChiaCollector) Collect(ch chan<- prometheus.Metric) {
 	cc.collectConnections(ch)
 	cc.collectBlockchainState(ch)
 	cc.collectWallets(ch)
-	cc.collectPoolState(ch)
 }
 
 func (cc ChiaCollector) collectConnections(ch chan<- prometheus.Metric) {
@@ -434,58 +430,4 @@ func (cc ChiaCollector) collectFarmedAmount(ch chan<- prometheus.Metric, w Walle
 		float64(farmed.PoolRewardAmount),
 		w.StringID, w.PublicKey,
 	)
-}
-
-func (cc ChiaCollector) collectPoolState(ch chan<- prometheus.Metric) {
-  var pools PoolState
-  if err := queryAPI(cc.client, cc.farmerURL, "get_pool_state", "", &pools); err != nil {
-    log.Print(err)
-    return
-  }
-	for _, p := range pools.PoolState {
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_current_difficulty",
-			  "Current difficulty on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(p.CurrentDificulty),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_current_points",
-			  "Current points on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(p.CurrentPoints),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_points_acknowledged_24h",
-			  "Points acknowledged last 24h on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(len(p.PointsAcknowledged24h)),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_points_found_24h",
-			  "Points found last 24h on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(len(p.PointsFound24h)),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-  }
 }

--- a/main.go
+++ b/main.go
@@ -39,10 +39,11 @@ var (
 	key    = flag.String("key", "$HOME/.chia/mainnet/config/ssl/full_node/private_full_node.key", "The full node SSL key.")
 	url    = flag.String("url", "https://localhost:8555", "The base URL for the full node RPC endpoint.")
 	wallet = flag.String("wallet", "https://localhost:9256", "The base URL for the wallet RPC endpoint.")
+	farmer = flag.String("farmer", "https://localhost:8559", "The base URL for the farmer RPC endpoint.")
 )
 
 var (
-	Version = "0.4.1"
+	Version = "0.4.1c"
 )
 
 func main() {
@@ -64,6 +65,7 @@ func main() {
 		client:    client,
 		baseURL:   *url,
 		walletURL: *wallet,
+		farmerURL: *farmer,
 	}
 	prometheus.MustRegister(cc)
 
@@ -128,6 +130,7 @@ type ChiaCollector struct {
 	client    *http.Client
 	baseURL   string
 	walletURL string
+	farmerURL string
 }
 
 // Describe is implemented with DescribeByCollect.
@@ -140,6 +143,7 @@ func (cc ChiaCollector) Collect(ch chan<- prometheus.Metric) {
 	cc.collectConnections(ch)
 	cc.collectBlockchainState(ch)
 	cc.collectWallets(ch)
+	cc.collectPoolState(ch)
 }
 
 func (cc ChiaCollector) collectConnections(ch chan<- prometheus.Metric) {
@@ -370,4 +374,58 @@ func (cc ChiaCollector) collectWalletSync(ch chan<- prometheus.Metric, w Wallet)
 		float64(whi.Height),
 		w.StringID, w.PublicKey,
 	)
+}
+
+func (cc ChiaCollector) collectPoolState(ch chan<- prometheus.Metric) {
+  var pools PoolState
+  if err := queryAPI(cc.client, cc.farmerURL, "get_pool_state", "", &pools); err != nil {
+    log.Print(err)
+    return
+  }
+	for _, p := range pools.PoolState {
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_current_difficulty",
+			  "Current difficulty on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(p.CurrentDificulty),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_current_points",
+			  "Current points on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(p.CurrentPoints),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_points_acknowledged_24h",
+			  "Points acknowledged last 24h on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(len(p.PointsAcknowledged24h)),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_points_found_24h",
+			  "Points found last 24h on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(len(p.PointsFound24h)),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+  }
 }


### PR DESCRIPTION
Added data from get_farmed_amount API

```
# HELP chia_wallet_farmed_amount Farmed amount
# TYPE chia_wallet_farmed_amount gauge
chia_wallet_farmed_amount{wallet_fingerprint="xxxx",wallet_id="1"} 0
chia_wallet_farmed_amount{wallet_fingerprint="xxxx",wallet_id="2"} 0

# HELP chia_wallet_fee_amount Fee amount amount
# TYPE chia_wallet_fee_amount gauge
chia_wallet_fee_amount{wallet_fingerprint="xxxx",wallet_id="1"} 0
chia_wallet_fee_amount{wallet_fingerprint="xxxx",wallet_id="2"} 0

# HELP chia_wallet_last_height_farmed Last height farmed
# TYPE chia_wallet_last_height_farmed gauge
chia_wallet_last_height_farmed{wallet_fingerprint="xxxx",wallet_id="1"} 0
chia_wallet_last_height_farmed{wallet_fingerprint="xxxx",wallet_id="2"} 0

# HELP chia_wallet_pool_reward_amount Pool Reward amount
# TYPE chia_wallet_pool_reward_amount gauge
chia_wallet_pool_reward_amount{wallet_fingerprint="xxxx",wallet_id="1"} 0
chia_wallet_pool_reward_amount{wallet_fingerprint="xxxx",wallet_id="2"} 0

# HELP chia_wallet_reward_amount Reward amount
# TYPE chia_wallet_reward_amount gauge
chia_wallet_reward_amount{wallet_fingerprint="xxxx",wallet_id="1"} 0
chia_wallet_reward_amount{wallet_fingerprint="xxxx",wallet_id="2"} 0
```