### PR TITLE
get pool state data

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,7 @@ endpoint. The wallet metrics are collected for each wallet, and include
   [get_height_info](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces#get_height_info)
   endpoint.
 
+* Pool state is collected from the
+  [get_pool_state](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces#get_pool_state)
+  endpoint (not yet documented). Need chia client version 1.2.0 or later
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ chia_wallet_sync_status{wallet_id="1",wallet_fingerprint="103402894"} 0
 # HELP chia_wallet_unconfirmed_balance_mojo Unconfirmed wallet balance.
 # TYPE chia_wallet_unconfirmed_balance_mojo gauge
 chia_wallet_unconfirmed_balance_mojo{wallet_id="1",wallet_fingerprint="103402894"} 100
+# HELP chia_pool_current_difficulty Current difficulty on pool.
+# TYPE chia_pool_current_difficulty gauge
+chia_pool_current_difficulty{launcher_id="0x...",pool_url="https://pool.yyy.y"} 1
+# HELP chia_pool_current_points Current points on pool.
+# TYPE chia_pool_current_points gauge
+chia_pool_current_points{launcher_id="0x...",pool_url="https://pool.yyy.y"} 12
+# HELP chia_pool_points_acknowledged_24h Points acknowledged last 24h on pool.
+# TYPE chia_pool_points_acknowledged_24h gauge
+chia_pool_points_acknowledged_24h{launcher_id="0x...",pool_url="https://pool.yyy.y"} 5
+# HELP chia_pool_points_found_24h Points found last 24h on pool.
+# TYPE chia_pool_points_found_24h gauge
+chia_pool_points_found_24h{launcher_id="0x...",pool_url="https://pool.xchpool.org"} 5
+
 ```
 
 ### Blockchain

--- a/chia.go
+++ b/chia.go
@@ -131,15 +131,15 @@ type WalletPublicKeys struct {
 }
 
 type PoolState struct {
-  PoolState             []struct {
-    CurrentDificulty      int64     `json:"current_difficulty"`
-    CurrentPoints         int64     `json:"current_points"`
-    PointsAcknowledged24h []interface{}   `json:"points_acknowledged_24h"`
-    PointsFound24h        []interface{}   `json:"points_found_24h"`
-    PoolConfig            struct {
-      LauncherId            string     `json:"launcher_id"`
-      PoolURL               string     `json:"pool_url"`
-    } `json:"pool_config"`
-  }      `json:"pool_state"`
-	Success               bool
+	PoolState []struct {
+		CurrentDificulty      int64         `json:"current_difficulty"`
+		CurrentPoints         int64         `json:"current_points"`
+		PointsAcknowledged24h []interface{} `json:"points_acknowledged_24h"`
+		PointsFound24h        []interface{} `json:"points_found_24h"`
+		PoolConfig            struct {
+			LauncherId string `json:"launcher_id"`
+			PoolURL    string `json:"pool_url"`
+		} `json:"pool_config"`
+	} `json:"pool_state"`
+	Success bool
 }

--- a/chia.go
+++ b/chia.go
@@ -134,8 +134,8 @@ type PoolState struct {
 	PoolState []struct {
 		CurrentDificulty      int64         `json:"current_difficulty"`
 		CurrentPoints         int64         `json:"current_points"`
-		PointsAcknowledged24h []interface{} `json:"points_acknowledged_24h"`
-		PointsFound24h        []interface{} `json:"points_found_24h"`
+		PointsAcknowledged24h [][2]float64  `json:"points_acknowledged_24h"`
+		PointsFound24h        [][2]float64  `json:"points_found_24h"`
 		PoolConfig            struct {
 			LauncherId string `json:"launcher_id"`
 			PoolURL    string `json:"pool_url"`

--- a/chia.go
+++ b/chia.go
@@ -129,3 +129,17 @@ type WalletPublicKeys struct {
 	PublicKeyFingerprints []int `json:"public_key_fingerprints"`
 	Success               bool
 }
+
+type PoolState struct {
+  PoolState             []struct {
+    CurrentDificulty      int64     `json:"current_difficulty"`
+    CurrentPoints         int64     `json:"current_points"`
+    PointsAcknowledged24h []interface{}   `json:"points_acknowledged_24h"`
+    PointsFound24h        []interface{}   `json:"points_found_24h"`
+    PoolConfig            struct {
+      LauncherId            string     `json:"launcher_id"`
+      PoolURL               string     `json:"pool_url"`
+    } `json:"pool_config"`
+  }      `json:"pool_state"`
+	Success               bool
+}

--- a/main.go
+++ b/main.go
@@ -377,55 +377,55 @@ func (cc ChiaCollector) collectWalletSync(ch chan<- prometheus.Metric, w Wallet)
 }
 
 func (cc ChiaCollector) collectPoolState(ch chan<- prometheus.Metric) {
-  var pools PoolState
-  if err := queryAPI(cc.client, cc.farmerURL, "get_pool_state", "", &pools); err != nil {
-    log.Print(err)
-    return
-  }
+	var pools PoolState
+	if err := queryAPI(cc.client, cc.farmerURL, "get_pool_state", "", &pools); err != nil {
+		log.Print(err)
+		return
+	}
 	for _, p := range pools.PoolState {
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_current_difficulty",
-			  "Current difficulty on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(p.CurrentDificulty),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_current_points",
-			  "Current points on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(p.CurrentPoints),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_points_acknowledged_24h",
-			  "Points acknowledged last 24h on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(len(p.PointsAcknowledged24h)),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-	  ch <- prometheus.MustNewConstMetric(
-		  prometheus.NewDesc(
-			  "chia_pool_points_found_24h",
-			  "Points found last 24h on pool.",
-			  []string{"launcher_id","pool_url"}, nil,
-		  ),
-		  prometheus.GaugeValue,
-		  float64(len(p.PointsFound24h)),
-      p.PoolConfig.LauncherId,
-      p.PoolConfig.PoolURL,
-	  )
-  }
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"chia_pool_current_difficulty",
+				"Current difficulty on pool.",
+				[]string{"launcher_id", "pool_url"}, nil,
+			),
+			prometheus.GaugeValue,
+			float64(p.CurrentDificulty),
+			p.PoolConfig.LauncherId,
+			p.PoolConfig.PoolURL,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"chia_pool_current_points",
+				"Current points on pool.",
+				[]string{"launcher_id", "pool_url"}, nil,
+			),
+			prometheus.GaugeValue,
+			float64(p.CurrentPoints),
+			p.PoolConfig.LauncherId,
+			p.PoolConfig.PoolURL,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"chia_pool_points_acknowledged_24h",
+				"Points acknowledged last 24h on pool.",
+				[]string{"launcher_id", "pool_url"}, nil,
+			),
+			prometheus.GaugeValue,
+			float64(len(p.PointsAcknowledged24h)),
+			p.PoolConfig.LauncherId,
+			p.PoolConfig.PoolURL,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"chia_pool_points_found_24h",
+				"Points found last 24h on pool.",
+				[]string{"launcher_id", "pool_url"}, nil,
+			),
+			prometheus.GaugeValue,
+			float64(len(p.PointsFound24h)),
+			p.PoolConfig.LauncherId,
+			p.PoolConfig.PoolURL,
+		)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -39,10 +39,11 @@ var (
 	key    = flag.String("key", "$HOME/.chia/mainnet/config/ssl/full_node/private_full_node.key", "The full node SSL key.")
 	url    = flag.String("url", "https://localhost:8555", "The base URL for the full node RPC endpoint.")
 	wallet = flag.String("wallet", "https://localhost:9256", "The base URL for the wallet RPC endpoint.")
+	farmer = flag.String("farmer", "https://localhost:8559", "The base URL for the farmer RPC endpoint.")
 )
 
 var (
-	Version = "0.4.1"
+	Version = "0.4.1c"
 )
 
 func main() {
@@ -64,6 +65,7 @@ func main() {
 		client:    client,
 		baseURL:   *url,
 		walletURL: *wallet,
+		farmerURL: *farmer,
 	}
 	prometheus.MustRegister(cc)
 
@@ -128,6 +130,7 @@ type ChiaCollector struct {
 	client    *http.Client
 	baseURL   string
 	walletURL string
+	farmerURL string
 }
 
 // Describe is implemented with DescribeByCollect.
@@ -140,6 +143,7 @@ func (cc ChiaCollector) Collect(ch chan<- prometheus.Metric) {
 	cc.collectConnections(ch)
 	cc.collectBlockchainState(ch)
 	cc.collectWallets(ch)
+	cc.collectPoolState(ch)
 }
 
 func (cc ChiaCollector) collectConnections(ch chan<- prometheus.Metric) {
@@ -370,4 +374,58 @@ func (cc ChiaCollector) collectWalletSync(ch chan<- prometheus.Metric, w Wallet)
 		float64(whi.Height),
 		w.StringID, w.PublicKey,
 	)
+}
+
+func (cc ChiaCollector) collectPoolState(ch chan<- prometheus.Metric) {
+  var pools PoolState
+  if err := queryAPI(cc.client, cc.farmerURL, "get_pool_state", "", &pools); err != nil {
+    log.Print(err)
+    return
+  }
+	for _, p := range pools.PoolState {
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_current_difficulty",
+			  "Current difficulty on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(p.CurrentDificulty),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_current_points",
+			  "Current points on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(p.CurrentPoints),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_points_acknowledged_24h",
+			  "Points acknowledged last 24h on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(len(p.PointsAcknowledged24h)),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_points_found_24h",
+			  "Points found last 24h on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(len(p.PointsFound24h)),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+  }
 }


### PR DESCRIPTION
Some data from farmer API get_pool_state

```
# HELP chia_pool_current_difficulty Current difficulty on pool.
# TYPE chia_pool_current_difficulty gauge
chia_pool_current_difficulty{launcher_id="0x...",pool_url="https://pool.yyy.y"} 1

# HELP chia_pool_current_points Current points on pool.
# TYPE chia_pool_current_points gauge
chia_pool_current_points{launcher_id="0x...",pool_url="https://pool.yyy.y"} 12

# HELP chia_pool_points_acknowledged_24h Points acknowledged last 24h on pool.
# TYPE chia_pool_points_acknowledged_24h gauge
chia_pool_points_acknowledged_24h{launcher_id="0x...",pool_url="https://pool.yyy.y"} 5

# HELP chia_pool_points_found_24h Points found last 24h on pool.
# TYPE chia_pool_points_found_24h gauge
chia_pool_points_found_24h{launcher_id="0x...",pool_url="https://pool.xchpool.org"} 5

```