### PR TITLE
Get plots details

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ chia_plots_failed_to_open 0
 # HELP chia_plots_not_found Number of plots files not found.
 # TYPE chia_plots_not_found gauge
 chia_plots_not_found 0
+# HELP chia_plots_file_size Chia plots file size.
+# TYPE chia_plots_file_size gauge
+chia_plots_file_size{k="32",plot_id="0x0...",pool_contract="",public_key="0x0..."} 1.08823675793e+11
+chia_plots_file_size{k="32",plot_id="0x0...",pool_contract="0x0...",public_key="0x0..."} 1.08810414936e+11
 ```
 
 ### Blockchain and Connections (full node)

--- a/chia.go
+++ b/chia.go
@@ -129,3 +129,12 @@ type WalletPublicKeys struct {
 	PublicKeyFingerprints []int `json:"public_key_fingerprints"`
 	Success               bool
 }
+
+type FarmedAmount struct {
+  FarmedAmount          int64    `json:"farmed_amount"`
+	RewardAmount          int64    `json:"farmer_reward_amount"`
+	FeeAmount             int64    `json:"fee_amount"`
+	LastHeightFarmed      int64    `json:"last_height_farmed"`
+	PoolRewardAmount      int64    `json:"pool_reward_amount"`
+	Success               bool
+}

--- a/chia.go
+++ b/chia.go
@@ -129,3 +129,10 @@ type WalletPublicKeys struct {
 	PublicKeyFingerprints []int `json:"public_key_fingerprints"`
 	Success               bool
 }
+
+type PlotFiles struct {
+	FailedToOpen          []interface{}      `json:"failed_to_open_filenames"`
+	NotFound              []interface{}      `json:"not_found_filenames"`
+	Plots                 []interface{}      `json:"plots"`
+	Success               bool
+}

--- a/chia.go
+++ b/chia.go
@@ -129,3 +129,17 @@ type WalletPublicKeys struct {
 	PublicKeyFingerprints []int `json:"public_key_fingerprints"`
 	Success               bool
 }
+
+type PoolState struct {
+  PoolState             []struct {
+    CurrentDificulty      int64     `json:"current_difficulty"`
+    CurrentPoints         int64     `json:"current_points"`
+    PointsAcknowledged24h []interface{}   `json:"points_acknowledged_24h"`
+    PointsFound24h        []interface{}   `json:"points_found_24h"`
+    PoolConfig            struct {
+      LauncherId            string     `json:"launcher_id"`
+      PoolURL               string     `json:"pool_url"`
+    } `json:"pool_config"`
+  }      `json:"pool_state"`
+	Success               bool
+}

--- a/main.go
+++ b/main.go
@@ -441,6 +441,21 @@ func (cc ChiaCollector) collectPlots(ch chan<- prometheus.Metric) {
 		log.Print(err)
 		return
 	}
+       for _, p := range plots.Plots {
+               ch <- prometheus.MustNewConstMetric(
+                       prometheus.NewDesc(
+                               "chia_plots_file_size",
+                               "Chia plots file size.",
+                               []string{"plot_id", "public_key", "pool_contract", "k"}, nil,
+                       ),
+                       prometheus.GaugeValue,
+                       float64(p.FileSize),
+                       p.PlotID,
+                       p.PublicKey,
+                       p.PoolContract,
+                       strconv.FormatInt(p.Size, 10),
+               )
+       }
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			"chia_plots_failed_to_open",

--- a/main.go
+++ b/main.go
@@ -441,21 +441,6 @@ func (cc ChiaCollector) collectPlots(ch chan<- prometheus.Metric) {
 		log.Print(err)
 		return
 	}
-       for _, p := range plots.Plots {
-               ch <- prometheus.MustNewConstMetric(
-                       prometheus.NewDesc(
-                               "chia_plots_file_size",
-                               "Chia plots file size.",
-                               []string{"plot_id", "public_key", "pool_contract", "k"}, nil,
-                       ),
-                       prometheus.GaugeValue,
-                       float64(p.FileSize),
-                       p.PlotID,
-                       p.PublicKey,
-                       p.PoolContract,
-                       strconv.FormatInt(p.Size, 10),
-               )
-       }
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			"chia_plots_failed_to_open",
@@ -474,15 +459,20 @@ func (cc ChiaCollector) collectPlots(ch chan<- prometheus.Metric) {
 		prometheus.GaugeValue,
 		float64(len(plots.NotFound)),
 	)
-	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			"chia_plots",
-			"Number of plots currently using.",
-			nil, nil,
-		),
-		prometheus.GaugeValue,
-		float64(len(plots.Plots)),
-	)
+	for _, p := range plots.Plots {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				"chia_plots",
+				"Data of the plots currently using.",
+				[]string{"k", "public_key", "pool_contract"}, nil,
+			),
+			prometheus.GaugeValue,
+			p.PlotID,
+			p.Size,
+			p.PublicKey,
+			p.PoolContract,
+		)
+	}
 }
 
 func (cc ChiaCollector) collectFarmedAmount(ch chan<- prometheus.Metric, w Wallet) {

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 		client:    client,
 		baseURL:   *url,
 		walletURL: *wallet,
+		harvesterURL: *harvester,
 	}
 	prometheus.MustRegister(cc)
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var (
 	key    = flag.String("key", "$HOME/.chia/mainnet/config/ssl/full_node/private_full_node.key", "The full node SSL key.")
 	url    = flag.String("url", "https://localhost:8555", "The base URL for the full node RPC endpoint.")
 	wallet = flag.String("wallet", "https://localhost:9256", "The base URL for the wallet RPC endpoint.")
-	farmer = flag.String("farmer", "https://localhost:8559", "The base URL for the farmer RPC endpoint.")
+	harvester = flag.String("harvester", "https://localhost:8560", "The base URL for the harvester RPC endpoint.")
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ var (
 )
 
 var (
-	Version = "0.4.1"
+	Version = "0.4.1a"
 )
 
 func main() {
@@ -237,6 +237,7 @@ func (cc ChiaCollector) collectWallets(ch chan<- prometheus.Metric) {
 		w.PublicKey = cc.getWalletPublicKey(w)
 		cc.collectWalletBalance(ch, w)
 		cc.collectWalletSync(ch, w)
+		cc.collectFarmedAmount(ch, w)
 	}
 }
 
@@ -368,6 +369,65 @@ func (cc ChiaCollector) collectWalletSync(ch chan<- prometheus.Metric, w Wallet)
 		walletHeightDesc,
 		prometheus.GaugeValue,
 		float64(whi.Height),
+		w.StringID, w.PublicKey,
+	)
+}
+
+func (cc ChiaCollector) collectFarmedAmount(ch chan<- prometheus.Metric, w Wallet) {
+	var farmed FarmedAmount
+	q := fmt.Sprintf(`{"wallet_id":%d}`, w.ID)
+	if err := queryAPI(cc.client, cc.walletURL, "get_farmed_amount", q, &farmed); err != nil {
+		log.Print(err)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_farmed_amount",
+		  "Farmed amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.FarmedAmount),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_reward_amount",
+		  "Reward amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.RewardAmount),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_fee_amount",
+		  "Fee amount amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.FeeAmount),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_last_height_farmed",
+		  "Last height farmed",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.LastHeightFarmed),
+		w.StringID, w.PublicKey,
+	)
+	ch <- prometheus.MustNewConstMetric(
+	  prometheus.NewDesc(
+		  "chia_wallet_pool_reward_amount",
+		  "Pool Reward amount",
+		  []string{"wallet_id", "wallet_fingerprint"}, nil,
+	  ),
+		prometheus.GaugeValue,
+		float64(farmed.PoolRewardAmount),
 		w.StringID, w.PublicKey,
 	)
 }

--- a/main.go
+++ b/main.go
@@ -39,10 +39,11 @@ var (
 	key    = flag.String("key", "$HOME/.chia/mainnet/config/ssl/full_node/private_full_node.key", "The full node SSL key.")
 	url    = flag.String("url", "https://localhost:8555", "The base URL for the full node RPC endpoint.")
 	wallet = flag.String("wallet", "https://localhost:9256", "The base URL for the wallet RPC endpoint.")
+	farmer = flag.String("farmer", "https://localhost:8559", "The base URL for the farmer RPC endpoint.")
 )
 
 var (
-	Version = "0.4.1"
+	Version = "0.4.1c"
 )
 
 func main() {
@@ -64,6 +65,7 @@ func main() {
 		client:    client,
 		baseURL:   *url,
 		walletURL: *wallet,
+		farmerURL: *farmer,
 	}
 	prometheus.MustRegister(cc)
 
@@ -128,6 +130,7 @@ type ChiaCollector struct {
 	client    *http.Client
 	baseURL   string
 	walletURL string
+	farmerURL string
 }
 
 // Describe is implemented with DescribeByCollect.
@@ -140,6 +143,7 @@ func (cc ChiaCollector) Collect(ch chan<- prometheus.Metric) {
 	cc.collectConnections(ch)
 	cc.collectBlockchainState(ch)
 	cc.collectWallets(ch)
+	cc.collectPoolState(ch)
 }
 
 func (cc ChiaCollector) collectConnections(ch chan<- prometheus.Metric) {
@@ -370,4 +374,58 @@ func (cc ChiaCollector) collectWalletSync(ch chan<- prometheus.Metric, w Wallet)
 		float64(whi.Height),
 		w.StringID, w.PublicKey,
 	)
+}
+
+func (cc ChiaCollector) collectPoolState(ch chan<- prometheus.Metric) {
+  var pools PoolState
+  if err := queryAPI(cc.client, cc.farmerURL, "get_pool_state", "", &pools); err != nil {
+    log.Print(err)
+    return
+  }
+	for _, p := range pools.PoolState {
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_current_difficulty",
+			  "Current difficulty on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(p.CurrentDificulty),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_current_points",
+			  "Current points on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(p.CurrentPoints),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_points_acknowledged_24h",
+			  "Points acknowledged last 24h on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(len(p.PointsAcknowledged24h)),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+	  ch <- prometheus.MustNewConstMetric(
+		  prometheus.NewDesc(
+			  "chia_pool_points_found_24h",
+			  "Points found last 24h on pool.",
+			  []string{"launcher_id","pool_url"}, nil,
+		  ),
+		  prometheus.GaugeValue,
+		  float64(len(p.PointsFound24h)),
+      p.PoolConfig.LauncherId,
+      p.PoolConfig.PoolURL,
+	  )
+  }
 }


### PR DESCRIPTION
Added details of the plot files, so we can distinguish OG and portables ones.

![plots](https://user-images.githubusercontent.com/63109594/125971542-06c2afd3-f478-4352-a1d7-d4913e5537c0.png)

I see that there are other commits in the PR, more than I have created in this branch. But the final changes on files looks fine. 