### PR TITLE
Automate building of Docker images into the GitHub registry.

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,55 @@
+name: Docker image
+
+on: push
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get the release channel
+        id: get_channel
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == 'refs/heads/master' ]]; then
+            echo ::set-output name=channel::"latest"
+            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/heads/"* ]]; then
+            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
+            echo ::set-output name=channel::${GITHUB_REF/refs\/tags\//}
+          fi
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.get_channel.outputs.channel }}
+            type=raw,value=${{ steps.get_channel.outputs.version }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine AS builder
 
 WORKDIR /build
-COPY . /build/chia_exporter
+COPY ./*.go go.mod go.sum /build/chia_exporter/
 RUN apk add --update --no-cache --virtual build-dependencies \
  && cd chia_exporter \
  && go build -tags netgo


### PR DESCRIPTION
There are already 3rd party images published on Dockerhub that are wildly out of date. So one automatically up to date official image is probably better than having people rely on unofficial images.

- Any push to the `master` branch updates the `:latest` label
- Any tag push to `master` will also be labeled with the tag name, so your releases will get stable labels.
- Any push to any other branch is labeled with the branch name and the short hash id of the commit.