### PR TITLE
Rebuild Dockerfile to run chia_exporter as a shim on Chia

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --update --no-cache --virtual build-dependencies \
  && cd chia_exporter \
  && go build -tags netgo
 
-FROM ghcr.io/chia-network/chia:latest
+FROM ghcr.io/chia-network/chia:1.2.11
 COPY --from=builder /build/chia_exporter/chia_exporter /usr/bin/chia_exporter
 COPY docker/exporter_init.sh /usr/local/bin/exporter_init.sh
 EXPOSE 9133

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,16 @@ RUN apk add --update --no-cache --virtual build-dependencies \
  && cd chia_exporter \
  && go build -tags netgo
 
-FROM alpine
+FROM ghcr.io/chia-network/chia:latest
 COPY --from=builder /build/chia_exporter/chia_exporter /usr/bin/chia_exporter
-
+COPY docker/exporter_init.sh /usr/local/bin/exporter_init.sh
 EXPOSE 9133
 
-ENV FULL_NODE_CERT=/chia_exporter/private_full_node.crt
-ENV FULL_NODE_KEY=/chia_exporter/private_full_node.key
+ENV CERT=/root/.chia/mainnet/config/ssl/full_node/private_full_node.crt
+ENV KEY=/root/.chia/mainnet/config/ssl/full_node/private_full_node.key
 ENV FULL_NODE_RPC_ENDPOINT=https://localhost:8555
 ENV WALLET_RPC_ENDPOINT=https://localhost:9256
+ENV FARMER_RPC_ENDPOINT=https://localhost:8559
+ENV HARVESTER_RPC_ENDPOINT=https://localhost:8560
 
-CMD /usr/bin/chia_exporter -cert $FULL_NODE_CERT -key $FULL_NODE_KEY -url $FULL_NODE_RPC_ENDPOINT -wallet $WALLET_RPC_ENDPOINT
+CMD /usr/local/bin/exporter_init.sh "$@"

--- a/docker/exporter_init.sh
+++ b/docker/exporter_init.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# build param stack
+args=()
+
+if [ -z "${FULL_NODE_RPC_ENDPOINT}" ]; then
+  >&2 echo "FULL_NODE_RPC_ENDPOINT not set, feature disabled."
+else
+  args+=("-url=$FULL_NODE_RPC_ENDPOINT")
+fi
+
+if [ -z "${WALLET_RPC_ENDPOINT}" ]; then
+  >&2 echo "WALLET_RPC_ENDPOINT not set, feature disabled."
+else
+  args+=("-wallet=$WALLET_RPC_ENDPOINT")
+fi
+
+if [ -z "${FARMER_RPC_ENDPOINT}" ]; then
+  >&2 echo "FARMER_RPC_ENDPOINT not set, feature disabled."
+else
+  args+=("-farmer=$FARMER_RPC_ENDPOINT")
+fi
+
+if [ -z "${HARVESTER_RPC_ENDPOINT}" ]; then
+  >&2 echo "HARVESTER_RPC_ENDPOINT not set, feature disabled."
+else
+  args+=("-harvester=$HARVESTER_RPC_ENDPOINT")
+fi
+
+/usr/bin/chia_exporter \
+  -cert "$CERT" -key "$KEY" \
+  "${args[@]}" &
+
+# Finally, exec the normal Chia docker-start
+exec /usr/local/bin/docker-start.sh


### PR DESCRIPTION
The latest official Chia image is used as a base and the exporter
defaults export it's metrics. Further env configuration is needed to
make the underlying Chia setup do what you want, for example be a
full_node or harvester.

This is far from ideal as a solution since it violates the separation of concerns running the exporter in the same container instead of as a sidecar. Right now though it's sort of necessary since Chia defaults to only listening on `127.0.0.1`, doesn't have any config hooks to override that per RPC service and doesn't even have a `configure` switch for changing the `local_hostname` which is used for RPC service binding. Thus the next best thing is to bring the exporter into the same container so it can access the default localhost-only RPC endpoints .